### PR TITLE
Multiple conditions per branch

### DIFF
--- a/fungus.nimble
+++ b/fungus.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version = "0.1.15"
+version = "0.1.16"
 author        = "Jason Beetham"
 description   = "A new awesome nimble package"
 license       = "MIT"

--- a/tests/tmulti.nim
+++ b/tests/tmulti.nim
@@ -1,0 +1,15 @@
+import fungus
+adtEnum(Shape):
+  None
+  Circle: tuple[x, y, r: int]
+  Rectangle: tuple[x, y, w, h: int]
+  Line: tuple[x1, y1, x2, y2: int]
+
+var a = Shape Circle.init(10, 10, 100)
+
+match a:
+of Circle as shape, Rectangle as shape:
+  echo shape.x, " ", shape.y
+of Line, None:
+  echo "A different shape"
+


### PR DESCRIPTION
Allows multiple `of` conditions to be attached to the same branch in a `match` statement. For example:

```
match a:
of Circle as shape, Rectangle as shape:
  echo shape.x, " ", shape.y
of Line, None:
  echo "A different shape"
```

Note that because of indentation changes you'll want to turn on "ignore whitespace" to see the significant parts of this change.